### PR TITLE
Edit to take input file name from command line input

### DIFF
--- a/325/Final Project/Final.py
+++ b/325/Final Project/Final.py
@@ -121,8 +121,8 @@ def main():
     random.seed(time.clock())
 
     # set up I/O files
-    #inputFileName = str(sys.argv[1])
-    inputFileName = sys.path[0] + "/tsp_example_3.txt"
+    inputFileName = str(sys.argv[1])
+    #inputFileName = sys.path[0] + "/tsp_example_3.txt"
     inputFile = open(inputFileName, 'r')
     outputFileName = inputFileName + ".tour"
     outputFile = open(outputFileName, 'w')
@@ -156,4 +156,3 @@ def main():
 
 if __name__ == '__main__':
   main()
-


### PR DESCRIPTION
Changed the input file name definition to read from the command line
parameters instead of the hard-coded file name.